### PR TITLE
fixed issue where multiple label arcs with same href would overwrite …

### DIFF
--- a/src/main/java/io/datanapis/xbrl/model/Location.java
+++ b/src/main/java/io/datanapis/xbrl/model/Location.java
@@ -15,8 +15,10 @@
  */
 package io.datanapis.xbrl.model;
 
+import com.google.common.hash.HashCode;
 import io.datanapis.xbrl.TagNames;
 import io.datanapis.xbrl.utils.Utils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.dom4j.Element;
 
 import java.util.Objects;
@@ -72,12 +74,12 @@ public final class Location {
 
         Location location = (Location) o;
 
-        return href.equals(location.href) && Objects.equals(label, ((Location) o).label);
+        return Objects.equals(href, location.href) && Objects.equals(label, location.label);
     }
 
     @Override
     public int hashCode() {
-        return href.hashCode();
+        return new HashCodeBuilder().append(href).append(label).hashCode();
     }
 
     public static Location fromElement(String sourceUrl, Element element) {


### PR DESCRIPTION
When there are multiple label arcs pointing to the same concept href, the Location `equals` method should check both href and label.

### Current: 
* equals depends only on href, so multiple locations with the same href will be considered the same
* as a consequence, the LabelLink arc map which maps locations to labels will contain only the last arc

### Example: 
I processed the files in https://www.sec.gov/Archives/edgar/data/34088/000003408820000073/0000034088-20-000073-index.html

The us-gaap_PaymentsOfDividendsCommonStock entry was getting `label = terse` instead of `label = negated` causing the presentation writer to return a positive number instead of a negative one.

**Full set of labels:**
![image](https://github.com/ammasjk/xbrlj/assets/3528114/ad490d33-1d3e-41db-9f21-14007a4d35b0)

**Preferred label**
![image](https://github.com/ammasjk/xbrlj/assets/3528114/49c793de-38fb-4bc1-86ab-23dbab2c50dc)
