### PR TITLE
extended matcher to allow for new definition of num-dot-decimal where…

### DIFF
--- a/src/main/java/io/datanapis/xbrl/utils/IxtTransform.java
+++ b/src/main/java/io/datanapis/xbrl/utils/IxtTransform.java
@@ -48,7 +48,7 @@ public class IxtTransform {
             Pattern.compile("^[ \\t\\n\\r]*([-]|\u002D|\u058A|\u05BE|\u2010|\u2011|\u2012|\u2013|\u2014|\u2015|\uFE58|\uFE63|\uFF0D)[ \\t\\n\\r]*$");
 
     private static final Pattern NUM_DOT_DECIMAL =
-            Pattern.compile("^[ \\t\\n\\r]*[0-9]{1,3}([, \u00A0]?[0-9]{3})*(\\.[0-9]+)?[ \\t\\n\\r]*$");
+            Pattern.compile("^[ \\t\\n\\r]*[0-9]{1,3}([, \u00A0]?[0-9]{3})*(\\.[0-9]+)?[ \\t\\n\\r]*$|^[ \\t\\n\\r]*(\\.[0-9]+)[ \\t\\n\\r]*$");
 
     private static final Pattern NUM_DOT_DECIMAL_IN =
             Pattern.compile("^(([0-9]{1,2}[, \u00A0])?([0-9]{2}[, \u00A0])*[0-9]{3})([.][0-9]+)?$|^([0-9]+)([.][0-9]+)?$");

--- a/src/test/java/io/datanapis/test/IxtTransformTest.java
+++ b/src/test/java/io/datanapis/test/IxtTransformTest.java
@@ -16,13 +16,41 @@
 package io.datanapis.test;
 
 import io.datanapis.xbrl.utils.IxtTransform;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class IxtTransformTest {
+
+    public static final String NUMBER_WITH_SPACE_AND_DECIMALS = "1 123.23";
+    public static final String NUMBER_WITH_COMMA_AND_DECIMALS = "1,123.23";
+    public static final String NUMBER_AND_DECIMALS = "1,123.23";
+    public static final String DECIMALS_ONLY = ".23";
+    public static final String NUM_DOT_DECIMAL_FORMAT = "num-dot-decimal";
 
     @Test
     public void testTransform() {
         String value = IxtTransform.parseDate("October 2026", "datemonthyearen");
         System.out.println(value);
+    }
+
+    @Test
+    public void testTransformNumberWithDecimals() {
+        final String expectedNumberAndDecimal = "1123.23";
+        Assert.assertEquals(expectedNumberAndDecimal,
+          IxtTransform.transformWithFormat(NUM_DOT_DECIMAL_FORMAT, NUMBER_WITH_SPACE_AND_DECIMALS));
+
+        Assert.assertEquals(expectedNumberAndDecimal,
+          IxtTransform.transformWithFormat(NUM_DOT_DECIMAL_FORMAT, NUMBER_WITH_COMMA_AND_DECIMALS));
+
+        Assert.assertEquals(expectedNumberAndDecimal,
+          IxtTransform.transformWithFormat(NUM_DOT_DECIMAL_FORMAT, NUMBER_AND_DECIMALS));
+
+    }
+
+    @Test
+    public void testTransformDecimalsOnly() {
+        final String expectedNumberAndDecimal = ".23";
+        Assert.assertEquals(expectedNumberAndDecimal,
+          IxtTransform.transformWithFormat(NUM_DOT_DECIMAL_FORMAT, DECIMALS_ONLY));
     }
 }


### PR DESCRIPTION
According to the documentation:
https://www.xbrl.org/Specification/inlineXBRL-transformationRegistry/CR-2019-04-19/inlineXBRL-transformationRegistry-CR-2019-04-19.html#sec-ixt-20

numbers can also start simply with the decimal part without integer part.
I.e. ".23"

![image](https://github.com/ammasjk/xbrlj/assets/3528114/31374db7-730b-4507-b098-023fd12ba8cd)


The current code throws an exception in this case, as it can't match numbers without the integer part.
As the rule states "The integer part is now optional if the dot and fractional part are present", I proposed in my change to add an alternative pattern to the matcher